### PR TITLE
Fix window drag on macOS

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -9,6 +9,7 @@
     "dialog:default",
     "shell:default",
     "fs:default",
-    "fs:allow-read"
+    "fs:allow-read",
+    "core:window:allow-start-dragging"
   ]
 }

--- a/src/lib/components/Chat.svelte
+++ b/src/lib/components/Chat.svelte
@@ -732,7 +732,7 @@
   aria-label="Chat"
 >
   <!-- Header -->
-  <header class="header drag-region">
+  <header class="header drag-region" data-tauri-drag-region>
     <div class="header-center no-drag">
       <div class="workspace-wrapper">
         <button class="workspace-btn" onclick={toggleWorkspaceMenu} title="Change workspace">


### PR DESCRIPTION
## Summary
- Add Tauri's `data-tauri-drag-region` attribute to the header element
- Enable the `core:window:allow-start-dragging` ACL permission

The app window couldn't be dragged on macOS because it uses `titleBarStyle: "Overlay"` but relied on Electron-style CSS (`-webkit-app-region: drag`) which Tauri ignores.

## Test plan
- [x] Restart the dev server (`bun run tauri dev`)
- [x] Click and hold the header area (top of the window, excluding buttons)
- [x] Drag the window around - it should move smoothly
- [x] Verify buttons in the header are still clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)