### PR TITLE
Add dark mode with light/dark/system toggle

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -49,6 +49,22 @@
   --transition-slow: 0.3s ease;
 }
 
+[data-theme="dark"] {
+  --white: #0f0f0f;
+  --off-black: #f0f0f0;
+  --off-black-soft: #e0e0e0;
+  --gray-50: #171717;
+  --gray-100: #1f1f1f;
+  --gray-200: #2d2d2d;
+  --gray-300: #404040;
+  --gray-400: #6b6b6b;
+  --gray-500: #9a9a9a;
+  --glass-gradient-start: rgba(30, 30, 30, 0.8);
+  --glass-gradient-end: rgba(30, 30, 30, 0.4);
+  --glass-border: rgba(255, 255, 255, 0.1);
+  --glass-shadow: rgba(0, 0, 0, 0.4);
+}
+
 *, *::before, *::after {
   box-sizing: border-box;
   margin: 0;

--- a/src/app.html
+++ b/src/app.html
@@ -8,6 +8,24 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+    <script>
+      (function() {
+        try {
+          const stored = localStorage.getItem('mensa-config');
+          if (stored) {
+            const config = JSON.parse(stored);
+            const theme = config.theme || 'system';
+            let effective = theme;
+            if (theme === 'system') {
+              effective = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+            }
+            if (effective === 'dark') {
+              document.documentElement.setAttribute('data-theme', 'dark');
+            }
+          }
+        } catch (e) {}
+      })();
+    </script>
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -817,4 +817,5 @@
     background: var(--gray-200);
     border-radius: 4px;
   }
+
 </style>

--- a/src/lib/services/theme.ts
+++ b/src/lib/services/theme.ts
@@ -1,0 +1,22 @@
+import { browser } from '$app/environment';
+import type { Theme } from '$lib/types';
+
+export function getEffectiveTheme(theme: Theme): 'light' | 'dark' {
+  if (theme === 'system') {
+    if (!browser) return 'light';
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+  return theme;
+}
+
+export function applyTheme(theme: Theme): void {
+  if (!browser) return;
+  document.documentElement.setAttribute('data-theme', getEffectiveTheme(theme));
+}
+
+export function subscribeToSystemTheme(callback: () => void): () => void {
+  if (!browser) return () => {};
+  const mq = window.matchMedia('(prefers-color-scheme: dark)');
+  mq.addEventListener('change', callback);
+  return () => mq.removeEventListener('change', callback);
+}

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -2,6 +2,8 @@
 
 export type AppState = 'onboarding' | 'chat';
 
+export type Theme = 'light' | 'dark' | 'system';
+
 export type OnboardingStep = 'welcome' | 'workspace' | 'ready';
 
 // Attachment types

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,10 +3,20 @@
   import { onMount } from 'svelte';
   import { browser } from '$app/environment';
   import { appState, appConfig } from '$lib/stores/app.svelte';
+  import { applyTheme, subscribeToSystemTheme } from '$lib/services/theme';
   import Onboarding from '$lib/components/Onboarding.svelte';
   import Chat from '$lib/components/Chat.svelte';
 
   let ready = $state(false);
+
+  // Apply theme reactively
+  $effect(() => {
+    if (!browser) return;
+    applyTheme(appConfig.theme);
+    if (appConfig.theme === 'system') {
+      return subscribeToSystemTheme(() => applyTheme('system'));
+    }
+  });
 
   onMount(() => {
     // Ensure hydration happened (should be automatic but let's be safe)


### PR DESCRIPTION
## Summary
- Add three theme options: Light, Dark, and System (follows OS preference)
- Theme toggle button in header cycles through all three modes
- Progressive disclosure: shows sun/moon icon on first use (for discoverability), reveals monitor icon after user interacts
- No flash on page load via inline script that applies theme before render
- Persisted preference via localStorage

## Changes
- **src/lib/types/index.ts**: Add `Theme` type
- **src/lib/stores/app.svelte.ts**: Add theme state, `themeUserSet` flag, and `setTheme()` method
- **src/lib/services/theme.ts**: New file with theme utilities
- **src/app.css**: Add dark mode CSS variables
- **src/app.html**: Add flash prevention script
- **src/routes/+page.svelte**: Add reactive theme application
- **src/lib/components/Chat.svelte**: Add theme toggle button to header
- **src/lib/components/Settings.svelte**: Remove unused appearance section

## Test plan
- [ ] Click theme button - should cycle: sun → moon → monitor → sun
- [ ] Verify theme persists after reload
- [ ] Set to System mode, change OS appearance - app should follow
- [ ] Clear localStorage, reload - should show sun/moon (not monitor) initially
- [ ] Check no white flash when loading in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)