### PR TITLE
Add vim mode input configuration option

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,13 +6,16 @@
       "name": "mensa",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.9",
+        "@codemirror/state": "^6.5.4",
+        "@codemirror/view": "^6.39.11",
         "@pierre/diffs": "^1.0.6",
+        "@replit/codemirror-vim": "^6.3.0",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",
         "@tauri-apps/plugin-fs": "^2.4.5",
         "@tauri-apps/plugin-opener": "^2",
         "@tauri-apps/plugin-shell": "^2.3.4",
-        "diff": "^7.0.0",
+        "codemirror": "^6.0.2",
         "marked": "^17.0.1",
         "nucleo-glass-icons": "^0.1.11",
       },
@@ -30,6 +33,20 @@
   },
   "packages": {
     "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.9", "", { "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.33.5", "@img/sharp-darwin-x64": "^0.33.5", "@img/sharp-linux-arm": "^0.33.5", "@img/sharp-linux-arm64": "^0.33.5", "@img/sharp-linux-x64": "^0.33.5", "@img/sharp-linuxmusl-arm64": "^0.33.5", "@img/sharp-linuxmusl-x64": "^0.33.5", "@img/sharp-win32-x64": "^0.33.5" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-b4JD6ZKCZeVDqpWBnb+zJISWi3HzlweNlV7Oy/uo5G2XAfUV2M5AJ/tomKZCvZsvmr1fYbmmfyde3GL2h0pksA=="],
+
+    "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.0", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-bOwvTOIJcG5FVo5gUUupiwYh8MioPLQ4UcqbcRf7UQ98X90tCa9E1kZ3Z7tqwpZxYyOvh1YTYbmZE9RTfTp5hg=="],
+
+    "@codemirror/commands": ["@codemirror/commands@6.10.1", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.4.0", "@codemirror/view": "^6.27.0", "@lezer/common": "^1.1.0" } }, "sha512-uWDWFypNdQmz2y1LaNJzK7fL7TYKLeUAU0npEC685OKTF3KcQ2Vu3klIM78D7I6wGhktme0lh3CuQLv0ZCrD9Q=="],
+
+    "@codemirror/language": ["@codemirror/language@6.12.1", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.23.0", "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0", "style-mod": "^4.0.0" } }, "sha512-Fa6xkSiuGKc8XC8Cn96T+TQHYj4ZZ7RdFmXA3i9xe/3hLHfwPZdM+dqfX0Cp0zQklBKhVD8Yzc8LS45rkqcwpQ=="],
+
+    "@codemirror/lint": ["@codemirror/lint@6.9.2", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.35.0", "crelt": "^1.0.5" } }, "sha512-sv3DylBiIyi+xKwRCJAAsBZZZWo82shJ/RTMymLabAdtbkV5cSKwWDeCgtUq3v8flTaXS2y1kKkICuRYtUswyQ=="],
+
+    "@codemirror/search": ["@codemirror/search@6.6.0", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.37.0", "crelt": "^1.0.5" } }, "sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw=="],
+
+    "@codemirror/state": ["@codemirror/state@6.5.4", "", { "dependencies": { "@marijn/find-cluster-break": "^1.0.0" } }, "sha512-8y7xqG/hpB53l25CIoit9/ngxdfoG+fx+V3SHBrinnhOtLvKHRyAJJuHzkWrR4YXXLX8eXBsejgAAxHUOdW1yw=="],
+
+    "@codemirror/view": ["@codemirror/view@6.39.11", "", { "dependencies": { "@codemirror/state": "^6.5.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-bWdeR8gWM87l4DB/kYSF9A+dVackzDb/V56Tq7QVrQ7rn86W0rgZFtlL3g3pem6AeGcb9NQNoy3ao4WpW4h5tQ=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 
@@ -123,9 +140,19 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@lezer/common": ["@lezer/common@1.5.0", "", {}, "sha512-PNGcolp9hr4PJdXR4ix7XtixDrClScvtSCYW3rQG106oVMOOI+jFb+0+J3mbeL/53g1Zd6s0kJzaw6Ri68GmAA=="],
+
+    "@lezer/highlight": ["@lezer/highlight@1.2.3", "", { "dependencies": { "@lezer/common": "^1.3.0" } }, "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g=="],
+
+    "@lezer/lr": ["@lezer/lr@1.4.7", "", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-wNIFWdSUfX9Jc6ePMzxSPVgTVB4EOfDIwLQLWASyiUdHKaMsiilj9bYiGkGQCKVodd0x6bgQCV207PILGFCF9Q=="],
+
+    "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.2", "", {}, "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="],
+
     "@pierre/diffs": ["@pierre/diffs@1.0.6", "", { "dependencies": { "@shikijs/core": "^3.0.0", "@shikijs/engine-javascript": "^3.0.0", "@shikijs/transformers": "^3.0.0", "diff": "8.0.2", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-VoFvtGCSPi+wAj4Ap+0j80/KPnQbYZsvztjIP4nHsjCgcVUBF7+X1nHFqjl/xbTqSc0okZG1tHYb49CUON9ZXQ=="],
 
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
+
+    "@replit/codemirror-vim": ["@replit/codemirror-vim@6.3.0", "", { "peerDependencies": { "@codemirror/commands": "6.x.x", "@codemirror/language": "6.x.x", "@codemirror/search": "6.x.x", "@codemirror/state": "6.x.x", "@codemirror/view": "6.x.x" } }, "sha512-aTx931ULAMuJx6xLf7KQDOL7CxD+Sa05FktTDrtLaSy53uj01ll3Zf17JdKsriER248oS55GBzg0CfCTjEneAQ=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.55.1", "", { "os": "android", "cpu": "arm" }, "sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg=="],
 
@@ -267,9 +294,13 @@
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
+    "codemirror": ["codemirror@6.0.2", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/commands": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/lint": "^6.0.0", "@codemirror/search": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw=="],
+
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
     "cookie": ["cookie@0.6.0", "", {}, "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="],
+
+    "crelt": ["crelt@1.0.6", "", {}, "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -281,7 +312,7 @@
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
-    "diff": ["diff@7.0.0", "", {}, "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw=="],
+    "diff": ["diff@8.0.2", "", {}, "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg=="],
 
     "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
@@ -375,6 +406,8 @@
 
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
+    "style-mod": ["style-mod@4.1.3", "", {}, "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ=="],
+
     "svelte": ["svelte@5.46.4", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/estree": "^1.0.5", "acorn": "^8.12.1", "aria-query": "^5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.6.2", "esm-env": "^1.2.1", "esrap": "^2.2.1", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-VJwdXrmv9L8L7ZasJeWcCjoIuMRVbhuxbss0fpVnR8yorMmjNDwcjIH08vS6wmSzzzgAG5CADQ1JuXPS2nwt9w=="],
 
     "svelte-check": ["svelte-check@4.3.5", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "chokidar": "^4.0.1", "fdir": "^6.2.0", "picocolors": "^1.0.0", "sade": "^1.7.4" }, "peerDependencies": { "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": ">=5.0.0" }, "bin": { "svelte-check": "bin/svelte-check" } }, "sha512-e4VWZETyXaKGhpkxOXP+B/d0Fp/zKViZoJmneZWe/05Y2aqSKj3YN2nLfYPJBQ87WEiY4BQCQ9hWGu9mPT1a1Q=="],
@@ -405,12 +438,12 @@
 
     "vitefu": ["vitefu@1.1.1", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0" }, "optionalPeers": ["vite"] }, "sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ=="],
 
+    "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
+
     "zimmerframe": ["zimmerframe@1.1.4", "", {}, "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="],
 
     "zod": ["zod@4.3.5", "", {}, "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
-
-    "@pierre/diffs/diff": ["diff@8.0.2", "", {}, "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,12 +22,16 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.9",
+    "@codemirror/state": "^6.5.4",
+    "@codemirror/view": "^6.39.11",
     "@pierre/diffs": "^1.0.6",
+    "@replit/codemirror-vim": "^6.3.0",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.6.0",
     "@tauri-apps/plugin-fs": "^2.4.5",
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-shell": "^2.3.4",
+    "codemirror": "^6.0.2",
     "marked": "^17.0.1",
     "nucleo-glass-icons": "^0.1.11"
   },

--- a/src/app.css
+++ b/src/app.css
@@ -140,3 +140,37 @@ body {
 .no-drag {
   -webkit-app-region: no-drag;
 }
+
+/* CodeMirror Vim Mode Styles */
+.cm-editor {
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+}
+
+.cm-editor .cm-scroller {
+  font-family: inherit;
+}
+
+.cm-editor.cm-focused {
+  outline: none;
+}
+
+/* Vim fat cursor in normal mode */
+.cm-editor .cm-fat-cursor .cm-cursor {
+  background: var(--off-black);
+  border: none;
+  width: 0.6em;
+}
+
+.cm-editor .cm-fat-cursor .cm-cursor-primary {
+  background: var(--off-black);
+}
+
+/* Selection highlighting */
+.cm-editor .cm-selectionBackground {
+  background: rgba(10, 10, 10, 0.12) !important;
+}
+
+[data-theme="dark"] .cm-editor .cm-selectionBackground {
+  background: rgba(255, 255, 255, 0.15) !important;
+}

--- a/src/lib/components/Chat.svelte
+++ b/src/lib/components/Chat.svelte
@@ -20,8 +20,10 @@
   import SessionTabs from './SessionTabs.svelte';
   import QuestionCard from './QuestionCard.svelte';
   import PlanApproval from './PlanApproval.svelte';
+  import VimInput from './VimInput.svelte';
 
   let inputValue = $state('');
+  let vimInputRef: { focus: () => void; getView: () => any } | undefined;
   let showSettings = $state(false);
   let showCommandPalette = $state(false);
   let showSessionPicker = $state(false);
@@ -1192,16 +1194,28 @@
                 <path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/>
               </svg>
             </button>
-            <textarea
-              bind:this={inputEl}
-              bind:value={inputValue}
-              placeholder="Message Claude..."
-              rows="1"
-              onkeydown={handleKeydown}
-              oninput={(e) => { autoResize(e); handleInput(); }}
-              onpaste={handlePaste}
-              disabled={isStreaming}
-            ></textarea>
+            {#if appConfig.claude.vimMode}
+              <VimInput
+                bind:this={vimInputRef}
+                bind:value={inputValue}
+                placeholder="Message Claude..."
+                disabled={isStreaming}
+                onsubmit={sendMessage}
+                oninput={handleInput}
+                onpaste={handlePaste}
+              />
+            {:else}
+              <textarea
+                bind:this={inputEl}
+                bind:value={inputValue}
+                placeholder="Message Claude..."
+                rows="1"
+                onkeydown={handleKeydown}
+                oninput={(e) => { autoResize(e); handleInput(); }}
+                onpaste={handlePaste}
+                disabled={isStreaming}
+              ></textarea>
+            {/if}
             <button
               class="plan-mode-btn"
               class:active={isPlanMode}
@@ -1300,7 +1314,11 @@
           {/if}
 
           <p class="input-hint">
-            <kbd>↵</kbd> send · <kbd>⇧↵</kbd> new line · <kbd>⇧⇥</kbd> plan mode{#if slashCommands.count > 0} · <kbd>/</kbd> commands{/if} · <kbd>@</kbd> files
+            {#if appConfig.claude.vimMode}
+              <kbd>↵</kbd> send (normal) · <kbd>i</kbd> insert · <kbd>Esc</kbd>/<kbd>jj</kbd> normal{#if slashCommands.count > 0} · <kbd>/</kbd> commands{/if} · <kbd>@</kbd> files
+            {:else}
+              <kbd>↵</kbd> send · <kbd>⇧↵</kbd> new line · <kbd>⇧⇥</kbd> plan mode{#if slashCommands.count > 0} · <kbd>/</kbd> commands{/if} · <kbd>@</kbd> files
+            {/if}
           </p>
         </div>
       </div>

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -125,6 +125,26 @@
             onchange={(e) => appConfig.setMaxTurns(parseInt(e.currentTarget.value) || 25)}
           />
         </div>
+
+        <div class="section">
+          <h3>Input Mode</h3>
+          <p class="hint">Choose your preferred text input style</p>
+
+          <div class="toggle-row">
+            <div class="toggle-label">
+              <span>Vim Mode</span>
+              <span class="toggle-hint">Use vim keybindings for text input (i=insert, Esc=normal, Enter=send)</span>
+            </div>
+            <label class="toggle">
+              <input
+                type="checkbox"
+                checked={appConfig.claude.vimMode}
+                onchange={(e) => appConfig.setVimMode(e.currentTarget.checked)}
+              />
+              <span class="toggle-slider"></span>
+            </label>
+          </div>
+        </div>
       {:else if activeTab === 'skills'}
         <div class="section">
           <h3>Skills & Commands</h3>

--- a/src/lib/components/VimInput.svelte
+++ b/src/lib/components/VimInput.svelte
@@ -1,0 +1,297 @@
+<script lang="ts">
+  import { onMount, onDestroy, tick } from 'svelte';
+  import { EditorView, drawSelection, placeholder as cmPlaceholder } from '@codemirror/view';
+  import { EditorState, Compartment } from '@codemirror/state';
+  import { vim, Vim, getCM } from '@replit/codemirror-vim';
+  import { getEffectiveTheme } from '$lib/services/theme';
+  import { appConfig } from '$lib/stores/app.svelte';
+
+  interface Props {
+    value: string;
+    placeholder?: string;
+    disabled?: boolean;
+    onsubmit: () => void;
+    oninput?: () => void;
+    onpaste?: (e: ClipboardEvent) => void;
+  }
+
+  let { value = $bindable(''), placeholder = 'Message Claude...', disabled = false, onsubmit, oninput, onpaste }: Props = $props();
+
+  let editorContainer: HTMLDivElement;
+  let view: EditorView | null = null;
+  let vimMode = $state<'normal' | 'insert' | 'visual'>('normal');
+  const themeCompartment = new Compartment();
+  const readOnlyCompartment = new Compartment();
+
+  // Reactive theme
+  const effectiveTheme = $derived(getEffectiveTheme(appConfig.theme));
+
+  // Light theme for CodeMirror
+  const lightTheme = EditorView.theme({
+    '&': {
+      backgroundColor: 'var(--gray-50)',
+      color: 'var(--off-black)',
+      fontSize: 'var(--text-base)',
+      fontFamily: 'var(--font-sans)',
+    },
+    '.cm-content': {
+      caretColor: 'var(--off-black)',
+      padding: '10px 12px',
+      minHeight: '20px',
+      maxHeight: '200px',
+    },
+    '.cm-line': {
+      padding: '0',
+    },
+    '.cm-cursor': {
+      borderLeftColor: 'var(--off-black)',
+      borderLeftWidth: '2px',
+    },
+    '.cm-cursor-primary': {
+      borderLeftColor: 'var(--off-black)',
+    },
+    '&.cm-focused': {
+      outline: 'none',
+    },
+    '.cm-scroller': {
+      overflow: 'auto',
+      maxHeight: '200px',
+    },
+    '.cm-placeholder': {
+      color: 'var(--gray-400)',
+    },
+    // Vim cursor styles
+    '.cm-fat-cursor': {
+      background: 'var(--off-black) !important',
+      color: 'var(--white) !important',
+    },
+    '.cm-cursor-secondary': {
+      borderLeftColor: 'var(--gray-400)',
+    },
+    '&.cm-focused .cm-selectionBackground, .cm-selectionBackground': {
+      backgroundColor: 'rgba(10, 10, 10, 0.15)',
+    },
+  }, { dark: false });
+
+  // Dark theme for CodeMirror
+  const darkTheme = EditorView.theme({
+    '&': {
+      backgroundColor: 'var(--gray-50)',
+      color: 'var(--off-black)',
+      fontSize: 'var(--text-base)',
+      fontFamily: 'var(--font-sans)',
+    },
+    '.cm-content': {
+      caretColor: 'var(--off-black)',
+      padding: '10px 12px',
+      minHeight: '20px',
+      maxHeight: '200px',
+    },
+    '.cm-line': {
+      padding: '0',
+    },
+    '.cm-cursor': {
+      borderLeftColor: 'var(--off-black)',
+      borderLeftWidth: '2px',
+    },
+    '.cm-cursor-primary': {
+      borderLeftColor: 'var(--off-black)',
+    },
+    '&.cm-focused': {
+      outline: 'none',
+    },
+    '.cm-scroller': {
+      overflow: 'auto',
+      maxHeight: '200px',
+    },
+    '.cm-placeholder': {
+      color: 'var(--gray-400)',
+    },
+    // Vim cursor styles
+    '.cm-fat-cursor': {
+      background: 'var(--off-black) !important',
+      color: 'var(--white) !important',
+    },
+    '.cm-cursor-secondary': {
+      borderLeftColor: 'var(--gray-400)',
+    },
+    '&.cm-focused .cm-selectionBackground, .cm-selectionBackground': {
+      backgroundColor: 'rgba(255, 255, 255, 0.15)',
+    },
+  }, { dark: true });
+
+  function getThemeExtension() {
+    return effectiveTheme === 'dark' ? darkTheme : lightTheme;
+  }
+
+  // Update editor content from external value changes
+  $effect(() => {
+    if (view && view.state.doc.toString() !== value) {
+      view.dispatch({
+        changes: { from: 0, to: view.state.doc.length, insert: value }
+      });
+    }
+  });
+
+  // Update theme when it changes
+  $effect(() => {
+    if (view) {
+      view.dispatch({
+        effects: themeCompartment.reconfigure(getThemeExtension())
+      });
+    }
+  });
+
+  // Update disabled state
+  $effect(() => {
+    if (view) {
+      view.dispatch({
+        effects: readOnlyCompartment.reconfigure(EditorState.readOnly.of(disabled))
+      });
+    }
+  });
+
+  onMount(() => {
+    // Map jj to Escape in insert mode
+    Vim.map('jj', '<Esc>', 'insert');
+
+    // Custom command to send message on Enter in normal mode
+    Vim.defineAction('sendMessage', () => {
+      onsubmit();
+    });
+    Vim.mapCommand('<CR>', 'action', 'sendMessage', {}, { context: 'normal' });
+
+    const updateListener = EditorView.updateListener.of((update) => {
+      if (update.docChanged) {
+        value = update.state.doc.toString();
+        oninput?.();
+      }
+
+      // Track vim mode changes
+      if (view) {
+        const cm = getCM(view);
+        if (cm) {
+          const state = cm.state;
+          if (state.vim) {
+            const vimState = state.vim as { visualMode?: boolean; insertMode?: boolean };
+            if (vimState.visualMode) {
+              vimMode = 'visual';
+            } else if (vimState.insertMode) {
+              vimMode = 'insert';
+            } else {
+              vimMode = 'normal';
+            }
+          }
+        }
+      }
+    });
+
+    // Handle paste events
+    const pasteHandler = EditorView.domEventHandlers({
+      paste: (event) => {
+        onpaste?.(event);
+        return false; // Let CodeMirror handle the paste
+      }
+    });
+
+    const state = EditorState.create({
+      doc: value,
+      extensions: [
+        vim(),
+        themeCompartment.of(getThemeExtension()),
+        readOnlyCompartment.of(EditorState.readOnly.of(disabled)),
+        drawSelection(),
+        cmPlaceholder(placeholder),
+        updateListener,
+        pasteHandler,
+        EditorView.lineWrapping,
+      ]
+    });
+
+    view = new EditorView({
+      state,
+      parent: editorContainer
+    });
+
+    // Focus the editor
+    view.focus();
+  });
+
+  onDestroy(() => {
+    view?.destroy();
+  });
+
+  export function focus() {
+    view?.focus();
+  }
+
+  export function getView() {
+    return view;
+  }
+</script>
+
+<div class="vim-input-wrapper">
+  <div class="vim-mode-indicator" class:insert={vimMode === 'insert'} class:visual={vimMode === 'visual'}>
+    {#if vimMode === 'normal'}
+      NORMAL
+    {:else if vimMode === 'insert'}
+      INSERT
+    {:else if vimMode === 'visual'}
+      VISUAL
+    {/if}
+  </div>
+  <div class="vim-editor" class:disabled bind:this={editorContainer}></div>
+</div>
+
+<style>
+  .vim-input-wrapper {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .vim-mode-indicator {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    padding: 2px 6px;
+    border-radius: var(--radius-sm);
+    background: var(--gray-200);
+    color: var(--gray-500);
+    align-self: flex-start;
+    margin-bottom: 4px;
+    transition: all var(--transition-fast);
+  }
+
+  .vim-mode-indicator.insert {
+    background: rgba(34, 197, 94, 0.15);
+    color: rgb(22, 163, 74);
+  }
+
+  .vim-mode-indicator.visual {
+    background: rgba(168, 85, 247, 0.15);
+    color: rgb(147, 51, 234);
+  }
+
+  .vim-editor {
+    flex: 1;
+    border-radius: var(--radius-md);
+    overflow: hidden;
+  }
+
+  .vim-editor.disabled {
+    opacity: 0.6;
+    pointer-events: none;
+  }
+
+  .vim-editor :global(.cm-editor) {
+    height: 100%;
+    border-radius: var(--radius-md);
+  }
+
+  .vim-editor :global(.cm-focused) {
+    outline: none;
+  }
+</style>

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -10,7 +10,8 @@ const DEFAULT_CLAUDE_CONFIG: ClaudeConfig = {
   skills: {
     enabled: true,
     settingSources: ['user', 'project']
-  }
+  },
+  vimMode: false
 };
 
 // App configuration persisted to localStorage
@@ -119,6 +120,11 @@ function createAppConfig() {
 
     setSkillsSettingSources(sources: SettingSource[]) {
       claude = { ...claude, skills: { ...claude.skills, settingSources: sources } };
+      save();
+    },
+
+    setVimMode(enabled: boolean) {
+      claude = { ...claude, vimMode: enabled };
       save();
     },
 

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -139,6 +139,7 @@ export interface ClaudeConfig {
   maxTurns: number;
   mcpServers: MCPServerConfig[];
   skills: SkillsConfig;
+  vimMode: boolean;
 }
 
 export interface AppConfig {


### PR DESCRIPTION
- Add vimMode config option to ClaudeConfig type and app store
- Create VimInput.svelte component using CodeMirror 6 + @replit/codemirror-vim
- Add vim mode toggle in Settings > General tab
- Conditionally render VimInput or textarea based on user preference
- Support vim keybindings: i=insert, Esc/jj=normal, Enter=send (in normal mode)
- Show vim mode indicator (NORMAL/INSERT/VISUAL)
- Add CodeMirror theme styles for light/dark mode support